### PR TITLE
Fixed rare (?) crash

### DIFF
--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -576,8 +576,9 @@
 		
 	} else if (!inPopover && _hiddenPopoverController && _barButtonItem) {
 		// I know this looks strange, but it fixes a bizarre issue with UIPopoverController leaving masterViewController's views in disarray.
-		[_hiddenPopoverController presentPopoverFromRect:CGRectZero inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:NO];
-		
+		if ([self.view superview])
+			[_hiddenPopoverController presentPopoverFromRect:CGRectZero inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:NO];
+
 		// Remove master from popover and destroy popover, if it exists.
 		[_hiddenPopoverController dismissPopoverAnimated:NO];
 		[_hiddenPopoverController release];


### PR DESCRIPTION
As described in the commit message, this crash occurred when we were holding on to a MGSplitViewController and presenting its view as a modal view twice, if the device orientation had changed between the two events (meaning between closing the modal view and presenting it again). The problem is that the clever hack will not work when the view is not yet a subview of any window. This is the error message we'd get:

**\* Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Popovers cannot be presented from a view which does not have a window.'

There might be a better way to fix the problem, but this worked for us.
