### PR TITLE
[MGSplitViewController shouldAutorotateToInterfaceOrientation:] overrides autorotate settings defined in the detail view controller.

### DIFF
--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -165,6 +165,11 @@
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
+    if (self.detailViewController)
+    {
+        return [self.detailViewController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+    }
+
     return YES;
 }
 


### PR DESCRIPTION
[MGSplitViewController shouldAutorotateToInterfaceOrientation:] currently returns YES for all orientations. If custom autorotate settings are defined in the detail view controller (for example Landscape only), MGSplitViewController ignores these settings and continues to autorotate for all orientations.

The patch modifies [MGSplitViewController shouldAutorotateToInterfaceOrientation:] to return the value of [detailViewController shouldAutorotateToInterfaceOrientation:] if detailViewController is available. Otherwise, it defaults to YES.
