### PR TITLE
"Popovers cannot be presented from a view which does not have a window." when in full screen modal

### DIFF
--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -576,8 +576,9 @@
 		
 	} else if (!inPopover && _hiddenPopoverController && _barButtonItem) {
 		// I know this looks strange, but it fixes a bizarre issue with UIPopoverController leaving masterViewController's views in disarray.
+if (self.view.window != nil) {
 		[_hiddenPopoverController presentPopoverFromRect:CGRectZero inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:NO];
-		
+		}
 		// Remove master from popover and destroy popover, if it exists.
 		[_hiddenPopoverController dismissPopoverAnimated:NO];
 		[_hiddenPopoverController release];


### PR DESCRIPTION
I found a bug when playing a mpmovieplayerviewcontroller inside a full screen modal.
Line 578 of mgsplitviewcontroller.m reads:
[_hiddenPopoverController presentPopoverFromRect:CGRectZero inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:NO];

but this causes a crash if self.view is not attached to a window.

So I added
if (self.view.window != nil) before that line and that worked.
