### PR TITLE
Better compatibility with UISplitViewController

### DIFF
--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -231,6 +231,11 @@
 	// Little bit ugly looking, but it'll still work even if they change the status bar height in future.
 	float statusBarHeight = MAX((fullScreenRect.size.width - appFrame.size.width), (fullScreenRect.size.height - appFrame.size.height));
 	
+	float navigationBarHeight = 0;
+	if ((self.navigationController)&&(!self.navigationController.navigationBarHidden)) {
+		navigationBarHeight = self.navigationController.navigationBar.frame.size.height;
+	}
+	
 	// Initially assume portrait orientation.
 	float width = fullScreenRect.size.width;
 	float height = fullScreenRect.size.height;
@@ -243,6 +248,7 @@
 	
 	// Account for status bar, which always subtracts from the height (since it's always at the top of the screen).
 	height -= statusBarHeight;
+	height -= navigationBarHeight;
 	
 	return CGSizeMake(width, height);
 }

--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -561,7 +561,11 @@
 		[self.masterViewController viewDidDisappear:NO];
 		
 		// Create and configure _barButtonItem.
-		_barButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Master", nil) 
+        NSString *barButtonItemTitle = self.masterViewController.title;
+        if (barButtonItemTitle == nil) {
+            barButtonItemTitle = @"Master";
+        }
+		_barButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(barButtonItemTitle, nil) 
 														  style:UIBarButtonItemStyleBordered 
 														 target:self 
 														 action:@selector(showMasterPopover:)];

--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -235,6 +235,11 @@
 	if ((self.navigationController)&&(!self.navigationController.navigationBarHidden)) {
 		navigationBarHeight = self.navigationController.navigationBar.frame.size.height;
 	}
+    
+    CGFloat tabBarHeight = 0;
+    if (self.tabBarController) {
+        tabBarHeight = self.tabBarController.tabBar.frame.size.height;
+    }
 	
 	// Initially assume portrait orientation.
 	float width = fullScreenRect.size.width;
@@ -249,6 +254,7 @@
 	// Account for status bar, which always subtracts from the height (since it's always at the top of the screen).
 	height -= statusBarHeight;
 	height -= navigationBarHeight;
+    height -= tabBarHeight;
 	
 	return CGSizeMake(width, height);
 }

--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -592,8 +592,9 @@
 		
 	} else if (!inPopover && _hiddenPopoverController && _barButtonItem) {
 		// I know this looks strange, but it fixes a bizarre issue with UIPopoverController leaving masterViewController's views in disarray.
+if (self.view.window != nil) {
 		[_hiddenPopoverController presentPopoverFromRect:CGRectZero inView:self.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:NO];
-		
+		}
 		// Remove master from popover and destroy popover, if it exists.
 		[_hiddenPopoverController dismissPopoverAnimated:NO];
 		[_hiddenPopoverController release];

--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -704,16 +704,21 @@
 
 - (IBAction)showMasterPopover:(id)sender
 {
-	if (_hiddenPopoverController && !(_hiddenPopoverController.popoverVisible)) {
-		// Inform delegate.
-		if (_delegate && [_delegate respondsToSelector:@selector(splitViewController:popoverController:willPresentViewController:)]) {
-			[(NSObject <MGSplitViewControllerDelegate> *)_delegate splitViewController:self 
-																	 popoverController:_hiddenPopoverController 
-															 willPresentViewController:self.masterViewController];
-		}
-		
-		// Show popover.
-		[_hiddenPopoverController presentPopoverFromBarButtonItem:_barButtonItem permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+	if (_hiddenPopoverController) {
+        if (_hiddenPopoverController.popoverVisible) {
+            [_hiddenPopoverController dismissPopoverAnimated:YES];
+        }
+        else {
+            // Inform delegate.
+            if (_delegate && [_delegate respondsToSelector:@selector(splitViewController:popoverController:willPresentViewController:)]) {
+                [(NSObject <MGSplitViewControllerDelegate> *)_delegate splitViewController:self 
+                                                                         popoverController:_hiddenPopoverController 
+                                                                 willPresentViewController:self.masterViewController];
+            }
+            
+            // Show popover.
+            [_hiddenPopoverController presentPopoverFromBarButtonItem:_barButtonItem permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+        }
 	}
 }
 


### PR DESCRIPTION
- When using `UISplitViewController`, the master view's popover is automatically dismissed when tapping its corresponding `UIBarButtonItem`, assuming the popover is visible. This commit should make `MGSplitViewController` match that behaviour.
- The bar button item title is set to the master view controller's title by default.
- Better view size calculations (navigation bar and tab bar are taken into account).
