### PR TITLE
Auto-rotate only when both master and detail want to.

### DIFF
--- a/Classes/MGSplitViewController.m
+++ b/Classes/MGSplitViewController.m
@@ -165,7 +165,15 @@
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
-    return YES;
+    if (self.masterViewController && self.detailViewController) {
+        return [self.masterViewController shouldAutorotateToInterfaceOrientation:interfaceOrientation] && [self.detailViewController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+    } else if (self.masterViewController) {
+        return [self.masterViewController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+    } else if (self.detailViewController) {
+        return [self.detailViewController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
+    } else {
+        return YES;
+    }
 }
 
 


### PR DESCRIPTION
Changed shouldAutorotateToInterfaceOrientation: to match the behavior of UISplitViewController where we don't autorotate unless all views support it.
